### PR TITLE
Track and terminate stuck runs

### DIFF
--- a/kill_stuck_runs.py
+++ b/kill_stuck_runs.py
@@ -6,106 +6,141 @@ Useful for cleaning up after crashes or force-quits.
 
 import os
 import sys
-import psutil
-from datetime import datetime, timedelta
+import signal
+from datetime import datetime
+
+try:
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover
+    psutil = None  # type: ignore
 
 # Add trainer to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'trainer'))
 
 from db import ExperimentDB
 
-def kill_stuck_runs(auto_mode=False):
+
+def kill_stuck_runs(auto_mode: bool = False, db_path: str = "experiments.db"):
     """Kill all training runs marked as 'running' in the database."""
-    db = ExperimentDB()
-    
+    db = ExperimentDB(db_path)
+
     # Get all running runs
     runs = db.get_runs(status='running')
-    
+
     if not runs:
         print("✓ No stuck runs found in database")
         return
-    
+
     print(f"\n⚠️  Found {len(runs)} stuck training runs:")
     print("-" * 60)
-    
+
     for run in runs:
         run_id = run['id']
         timestamp = run['timestamp']
         model = run['model']
         dataset = run['dataset']
-        
+
         # Check how old the run is
         try:
             run_time = datetime.fromisoformat(timestamp)
             age = datetime.now() - run_time
-            age_str = f"{age.days}d {age.seconds//3600}h" if age.days > 0 else f"{age.seconds//3600}h {(age.seconds%3600)//60}m"
-        except:
+            age_str = (
+                f"{age.days}d {age.seconds//3600}h"
+                if age.days > 0
+                else f"{age.seconds//3600}h {(age.seconds%3600)//60}m"
+            )
+        except Exception:
             age_str = "unknown"
-        
+
         print(f"  Run #{run_id}: {model} on {dataset}")
         print(f"    Started: {timestamp}")
         print(f"    Age: {age_str}")
-    
+
     print("-" * 60)
-    
+
     if not auto_mode:
         response = input("\n[?] Kill all stuck runs? (yes/no): ")
         if response.lower() not in ['yes', 'y']:
             print("Cancelled.")
             return
-    
+
     # Kill all stuck runs
     print("\n[*] Killing stuck runs...")
-    
+
     for run in runs:
         run_id = run['id']
+        pid = run.get('pid')
         try:
-            # Update database status
-            db.update_run(run_id, 
+            if pid:
+                if psutil:
+                    try:
+                        proc = psutil.Process(pid)
+                        proc.terminate()
+                        try:
+                            proc.wait(timeout=1)
+                        except psutil.TimeoutExpired:
+                            proc.kill()
+                    except (psutil.NoSuchProcess, psutil.AccessDenied):
+                        pass
+                else:
+                    try:
+                        os.kill(pid, signal.SIGTERM)
+                    except OSError:
+                        pass
+
+            # Update database status and clear pid
+            db.update_run(run_id,
                          status='failed',
-                         notes='Killed by cleanup script - process was stuck')
+                         notes='Killed by cleanup script - process was stuck',
+                         pid=None)
             print(f"  ✓ Killed run #{run_id}")
         except Exception as e:
             print(f"  ✗ Error killing run #{run_id}: {e}")
-    
+
     print("\n✓ Cleanup complete!")
-    
+
     # Also try to kill any orphaned Python processes running train_worker.py
-    print("\n[*] Checking for orphaned training processes...")
-    killed_processes = 0
-    
-    for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
-        try:
-            cmdline = proc.info.get('cmdline', [])
-            if cmdline and any('train_worker.py' in arg for arg in cmdline):
-                print(f"  Found orphaned process PID {proc.info['pid']}")
-                proc.terminate()
-                killed_processes += 1
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            continue
-    
-    if killed_processes > 0:
-        print(f"  ✓ Terminated {killed_processes} orphaned processes")
+    if psutil:
+        print("\n[*] Checking for orphaned training processes...")
+        killed_processes = 0
+
+        for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
+            try:
+                cmdline = proc.info.get('cmdline', [])
+                if cmdline and any('train_worker.py' in arg for arg in cmdline):
+                    print(f"  Found orphaned process PID {proc.info['pid']}")
+                    proc.terminate()
+                    killed_processes += 1
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+
+        if killed_processes > 0:
+            print(f"  ✓ Terminated {killed_processes} orphaned processes")
+        else:
+            print("  ✓ No orphaned processes found")
     else:
-        print("  ✓ No orphaned processes found")
+        print("\n[!] psutil not available - skipping orphaned process check")
+
 
 def main():
     """Main entry point."""
     import argparse
-    
+
     parser = argparse.ArgumentParser(description='Kill stuck training runs')
     parser.add_argument('--auto', '-a', action='store_true',
                        help='Automatically kill all stuck runs without confirmation')
     parser.add_argument('--dry-run', '-d', action='store_true',
                        help='Show what would be killed without actually doing it')
-    
+    parser.add_argument('--db-path', default='experiments.db',
+                       help='Path to experiments database')
+
     args = parser.parse_args()
-    
+
     if args.dry_run:
         print("DRY RUN MODE - No changes will be made")
-        db = ExperimentDB()
+        db = ExperimentDB(args.db_path)
         runs = db.get_runs(status='running')
-        
+
         if not runs:
             print("No stuck runs found")
         else:
@@ -113,7 +148,8 @@ def main():
             for run in runs:
                 print(f"  - Run #{run['id']}: {run['model']} on {run['dataset']}")
     else:
-        kill_stuck_runs(auto_mode=args.auto)
+        kill_stuck_runs(auto_mode=args.auto, db_path=args.db_path)
+
 
 if __name__ == "__main__":
     main()

--- a/test_kill_functionality.py
+++ b/test_kill_functionality.py
@@ -1,53 +1,35 @@
-#!/usr/bin/env python
-"""Test the kill functionality"""
+"""Tests for killing stuck training runs."""
 
-import sys
 import os
+import sys
+import subprocess
+
+# Add trainer to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'trainer'))
 
 from db import ExperimentDB
+from kill_stuck_runs import kill_stuck_runs
 
-def test_kill():
-    db = ExperimentDB()
-    
-    # Get all runs
-    all_runs = db.get_runs(limit=10)
-    print(f"\nTotal runs in database: {len(all_runs)}")
-    
-    for run in all_runs:
-        print(f"  Run #{run['id']}: {run['model']} on {run['dataset']} - Status: {run['status']}")
-    
-    # Get stuck runs
-    stuck_runs = db.get_runs(status='running')
-    print(f"\nStuck runs (status='running'): {len(stuck_runs)}")
-    
-    if stuck_runs:
-        print("\nStuck runs details:")
-        for run in stuck_runs:
-            print(f"  Run #{run['id']}: {run['model']} on {run['dataset']}")
-            print(f"    Started: {run['timestamp']}")
-            print(f"    Status: {run['status']}")
-            print(f"    Notes: {run.get('notes', 'None')}")
-        
-        # Test updating one
-        test_id = stuck_runs[0]['id']
-        print(f"\nTesting update on run #{test_id}...")
-        
-        try:
-            db.update_run(test_id, status='failed', notes='Test kill')
-            print(f"  ✓ Successfully updated run #{test_id}")
-            
-            # Verify the update
-            updated_run = db.get_run(test_id)
-            print(f"  Verification: Run #{test_id} status is now '{updated_run['status']}'")
-            
-        except Exception as e:
-            print(f"  ✗ Error updating run: {e}")
-            import traceback
-            traceback.print_exc()
-    else:
-        print("\nNo stuck runs to test with.")
-        print("All runs have status: completed or failed")
 
-if __name__ == "__main__":
-    test_kill()
+def test_kill_stuck_run_updates_db_and_terminates(tmp_path):
+    """Ensure kill_stuck_runs terminates processes and updates database."""
+    db_path = tmp_path / "test_experiments.db"
+    db = ExperimentDB(str(db_path))
+
+    # Create a dummy running process and corresponding DB entry
+    run_id = db.create_run("TestModel", "TestData", epochs=1, batch_size=1, lr=0.001)
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    db.update_run(run_id, pid=proc.pid)
+
+    # Kill stuck runs
+    kill_stuck_runs(auto_mode=True, db_path=str(db_path))
+
+    # Verify process was terminated
+    proc.wait(timeout=1)
+    assert proc.poll() is not None
+
+    # Verify database status updated
+    run = db.get_run(run_id)
+    assert run["status"] == "failed"
+    assert run["pid"] is None
+

--- a/trainer/db.py
+++ b/trainer/db.py
@@ -46,9 +46,16 @@ class ExperimentDB:
                     training_time REAL,  -- in seconds
                     status TEXT DEFAULT 'running',  -- running, completed, failed
                     notes TEXT,
-                    config TEXT  -- JSON string for additional config
+                    config TEXT,  -- JSON string for additional config
+                    pid INTEGER
                 )
             """)
+
+            # Add pid column if upgrading existing database
+            cursor.execute("PRAGMA table_info(runs)")
+            columns = [row[1] for row in cursor.fetchall()]
+            if 'pid' not in columns:
+                cursor.execute("ALTER TABLE runs ADD COLUMN pid INTEGER")
             
             # Create datasets table
             cursor.execute("""
@@ -108,7 +115,7 @@ class ExperimentDB:
         """Update run information."""
         allowed_fields = {
             'train_loss', 'val_loss', 'val_acc', 'best_val_acc',
-            'training_time', 'status', 'notes'
+            'training_time', 'status', 'notes', 'pid'
         }
         
         # Filter out non-allowed fields


### PR DESCRIPTION
## Summary
- add `pid` column to run records and allow updating it
- record worker PID and kill runs by PID from the GUI
- enhance kill_stuck_runs utility to terminate PIDs and handle missing psutil
- add regression test to ensure stuck runs are killed and marked failed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898034774f4832d95b9c269f9f55198